### PR TITLE
Update to 1.7 and only push on tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/$G
 ADD ./build.sh /scripts/build.sh
 
 RUN apk update \
-  && apk add ca-certificates wget \
+  && apk add git ca-certificates wget \
   && update-ca-certificates
 
 RUN wget -O glide.zip "$GLIDE_DOWNLOAD_URL"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.2
+FROM golang:1.7.0-alpine
 MAINTAINER charlie@vidsy.co
 
 ENV GLIDE_VERSION 0.10.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/$G
 
 ADD ./build.sh /scripts/build.sh
 
-RUN apk update
-RUN apk add ca-certificates wget
-RUN update-ca-certificates
+RUN apk update \
+  && apk add ca-certificates wget \
+  && update-ca-certificates
 
 RUN wget -O glide.zip "$GLIDE_DOWNLOAD_URL"
 RUN unzip glide.zip linux-amd64/glide

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/$G
 
 ADD ./build.sh /scripts/build.sh
 
-ENTRYPOINT ["/scripts/build.sh"]
+RUN apk update
+RUN apk add ca-certificates wget
+RUN update-ca-certificates
 
-RUN apt-get update \
-  && apt-get install -y unzip --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSL "$GLIDE_DOWNLOAD_URL" -o glide.zip \
-  && unzip glide.zip  linux-amd64/glide \
-  && mv linux-amd64/glide /usr/local/bin \
-  && rm -rf linux-amd64 \
-  && rm glide.zip
+RUN wget -O glide.zip "$GLIDE_DOWNLOAD_URL"
+RUN unzip glide.zip  linux-amd64/glide
+RUN mv linux-amd64/glide /usr/local/bin
+RUN rm -rf linux-amd64 glide.zip
+
+ENTRYPOINT ["/scripts/build.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add ca-certificates wget
 RUN update-ca-certificates
 
 RUN wget -O glide.zip "$GLIDE_DOWNLOAD_URL"
-RUN unzip glide.zip  linux-amd64/glide
+RUN unzip glide.zip linux-amd64/glide
 RUN mv linux-amd64/glide /usr/local/bin
 RUN rm -rf linux-amd64 glide.zip
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 glide install
 CGO_ENABLED=0 go build -a -installsuffix nocgo .

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 glide install
-GO15VENDOREXPERIMENT=1 CGO_ENABLED=0 go build -a -installsuffix nocgo .
+CGO_ENABLED=0 go build -a -installsuffix nocgo .

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,9 @@ test:
 
 deployment:
   hub:
-    branch: master
+    tag: /[0-9]+\.[0-9]+\.[0-9]+/
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker tag vidsyhq/go-builder:latest vidsyhq/go-builder:$CIRCLE_TAG
+      - docker push vidsyhq/go-builder:$CIRCLE_TAG
       - docker push vidsyhq/go-builder


### PR DESCRIPTION
### Problem

Version `1.7` of go lang is now out 🎆 , lets use it!
### Solution
- Update dockerfile to use latest version.
- Use alpine version to keep image size down.
- Remove `GO15VENDOREXPERIMENT` as default in `1.7`.
- Only push to docker hub on tag.
