### PR TITLE
Adds Make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/$G
 ADD ./build.sh /scripts/build.sh
 
 RUN apk update \
-  && apk add git ca-certificates wget \
+  && apk add make git ca-certificates wget \
   && update-ca-certificates
 
 RUN wget -O glide.zip "$GLIDE_DOWNLOAD_URL"


### PR DESCRIPTION
### Problem

Some of the Vidsy apps require `make` which we had in the original container but now having moved to alpine it's no longer available.
### Solution
- Add it!
