### PR TITLE
Adds ssh-client dep for glide to download private packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/$G
 ADD ./build.sh /scripts/build.sh
 
 RUN apk update \
-  && apk openssh-client add make git ca-certificates wget \
+  && apk add openssh-client make git ca-certificates wget \
   && update-ca-certificates
 
 RUN wget -O glide.zip "$GLIDE_DOWNLOAD_URL"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/$G
 ADD ./build.sh /scripts/build.sh
 
 RUN apk update \
-  && apk add make git ca-certificates wget \
+  && apk openssh-client add make git ca-certificates wget \
   && update-ca-certificates
 
 RUN wget -O glide.zip "$GLIDE_DOWNLOAD_URL"


### PR DESCRIPTION
### Problem

Builds are still breaking when trying to download private repos as `glide` expects there to be an `ssh` command available but since the change to `alpine` this isn't the case.
### Solution
- Add `ssh` via the package `openssh-client`.
