### PR TITLE
Allow configurable build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ MAINTAINER charlie@vidsy.co
 ENV GLIDE_VERSION 0.10.2
 ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.zip
 
-ADD ./build.sh /scripts/build.sh
-
 RUN apk update \
   && apk add openssh-client make git ca-certificates wget \
   && update-ca-certificates
@@ -14,5 +12,7 @@ RUN wget -O glide.zip "$GLIDE_DOWNLOAD_URL"
 RUN unzip glide.zip linux-amd64/glide
 RUN mv linux-amd64/glide /usr/local/bin
 RUN rm -rf linux-amd64 glide.zip
+
+ADD ./build.sh /scripts/build.sh
 
 ENTRYPOINT ["/scripts/build.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM golang:1.7.0-alpine
 MAINTAINER charlie@vidsy.co
 
-ENV GLIDE_VERSION 0.10.2
-ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.zip
+ENV GLIDE_VERSION 0.12.3
+ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/v$GLIDE_VERSION/glide-v$GLIDE_VERSION-linux-amd64.zip
+ENV CGO_ENABLED 0
 
 RUN apk update \
   && apk add openssh-client make git ca-certificates wget \

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Replace with correct `$GOPATH`. This will output a binary suitable to use with *
 
 Each of the following steps can be controlled with env vars:
 
-* INSTALL=true (Installs dependencies using glide).
-* BUILD=true (Builds the linux 64bit binary).
-* SETUP_SSH=false (Sets up the ssh config for use in circle CI for private repos).
+* `INSTALL=true` (Installs dependencies using glide).
+* `BUILD=true` (Builds the linux 64bit binary).
+* `SETUP_SSH=false` (Sets up the ssh config for use in circle CI for private repos).
 
 ### CircleCI
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ docker run --rm -v "$PWD":/go/src/github.com/org/repo -w /go/src/github.com/org/
 
 Replace with correct `$GOPATH`. This will output a binary suitable to use with **Alpine** Linux.
 
+#### Options
+
+Each of the following steps can be controlled with env vars:
+
+* INSTALL=true (Installs dependencies using glide).
+* BUILD=true (Builds the linux 64bit binary).
+* SETUP_SSH=false (Sets up the ssh config for use in circle CI for private repos).
+
 ### CircleCI
 
 ```yaml

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-INSTALL="${1:-true}"
-BUILD="${2:-true}"
-SETUP_SSH="${3:-false}"
+INSTALL="${INSTALL:-true}"
+BUILD="${BUILD:-true}"
+SETUP_SSH="${SETUP_SSH:-false}"
 USER=$(whoami)
 SSH_KEY_NAME="id_circleci_github"
 

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ USER=$(whoami)
 SSH_KEY_NAME="id_circleci_github"
 
 log () {
-	echo "[go-builder] => $1" 
+  echo "[go-builder] => $1" 
 } 
 
 if [ "$SETUP_SSH" == "true" ]; then

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,6 @@ if [ "$INSTALL" == "true" ]; then
 fi
 
 if [ "$BUILD" == "true" ]; then
-  env
   log "Building binary"
   go build -a -installsuffix nocgo .
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,30 @@
 #!/bin/sh
 
-glide install
-CGO_ENABLED=0 go build -a -installsuffix nocgo .
+INSTALL="${1:-true}"
+BUILD="${2:-true}"
+SETUP_SSH="${3:-false}"
+USER=$(whoami)
+SSH_KEY_NAME="id_circleci_github"
+
+log () {
+	echo "[go-builder] => $1" 
+} 
+
+if [ "$SETUP_SSH" == "true" ]; then
+	log "Setting up SSH config for private repos"
+	mkdir -p /$USER/.ssh
+	echo -e "Host github.com\nIdentitiesOnly yes\nIdentityFile /$USER/.ssh/$SSH_KEY_NAME\nStrictHostKeyChecking no\nUserKnownHostsFile=/dev/null" > /$USER/.ssh/config
+	chown -R $USER:$USER /$USER/.ssh
+	chmod 700 /$USER/.ssh
+	chmod 600 /$USER/.ssh/*
+fi
+
+if [ "$INSTALL" == "true" ]; then
+	log "Installing dependencies with glide"
+  glide install
+fi
+
+if [ "$BUILD" == "true" ]; then
+	log "Building binary"
+  CGO_ENABLED=0 go build -a -installsuffix nocgo .
+fi

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,7 @@ if [ "$INSTALL" == "true" ]; then
 fi
 
 if [ "$BUILD" == "true" ]; then
+  env
   log "Building binary"
-  CGO_ENABLED=0 go build -a -installsuffix nocgo .
+  go build -a -installsuffix nocgo .
 fi

--- a/build.sh
+++ b/build.sh
@@ -11,20 +11,20 @@ log () {
 } 
 
 if [ "$SETUP_SSH" == "true" ]; then
-	log "Setting up SSH config for private repos"
-	mkdir -p /$USER/.ssh
-	echo -e "Host github.com\nIdentitiesOnly yes\nIdentityFile /$USER/.ssh/$SSH_KEY_NAME\nStrictHostKeyChecking no\nUserKnownHostsFile=/dev/null" > /$USER/.ssh/config
-	chown -R $USER:$USER /$USER/.ssh
-	chmod 700 /$USER/.ssh
-	chmod 600 /$USER/.ssh/*
+  log "Setting up SSH config for private repos"
+  mkdir -p /$USER/.ssh
+  echo -e "Host github.com\nIdentitiesOnly yes\nIdentityFile /$USER/.ssh/$SSH_KEY_NAME\nStrictHostKeyChecking no\nUserKnownHostsFile=/dev/null" > /$USER/.ssh/config
+  chown -R $USER:$USER /$USER/.ssh
+  chmod 700 /$USER/.ssh
+  chmod 600 /$USER/.ssh/*
 fi
 
 if [ "$INSTALL" == "true" ]; then
-	log "Installing dependencies with glide"
+  log "Installing dependencies with glide"
   glide install
 fi
 
 if [ "$BUILD" == "true" ]; then
-	log "Building binary"
+  log "Building binary"
   CGO_ENABLED=0 go build -a -installsuffix nocgo .
 fi


### PR DESCRIPTION
### Problem

In a number of repos there's certain steps we only want to perform such as installing the reps or building the binary. There's also a lot of duplication when setting up the ssh config for private repos in circle ci.
### Solution
- Make each step configurable.
- Add a step for configuring the the ssh config for use in circle ci for private repos.
